### PR TITLE
support layout variants

### DIFF
--- a/i3-keyboard-layout
+++ b/i3-keyboard-layout
@@ -3,16 +3,19 @@
 set -e
 
 get_kbdlayout() {
-  setxkbmap -query | grep -oP 'layout:\s*\K(\w+)'
+  layout=$(setxkbmap -query | grep -oP 'layout:\s*\K(\w+)')
+  variant=$(setxkbmap -query | grep -oP 'variant:\s*\K(\w+)')
+  echo "$layout" "$variant"
 }
 
 set_kbdlayout() {
-  setxkbmap "$1"
+  eval "array=($1)"
+  setxkbmap "${array[@]}"
   pgrep i3status | xargs --no-run-if-empty kill -s USR1 # tell i3status to update
 }
 
 cycle() {
-  current_layout=$(get_kbdlayout)
+  current_layout=$(get_kbdlayout | xargs)
   layouts=("$@" "$1") # add the first one at the end so that it cycles
   index=0
   while [ "${layouts[$index]}" != "$current_layout" ] && [ $index -lt "${#layouts[@]}" ]; do index=$[index +1]; done


### PR DESCRIPTION
This PR makes it possible to switch between layouts with different layout variants.  

Example usage:  

`path/to/i3-keyboard-layout cycle "bg bds" "bg phonetic"`  
or  
`path/to/i3-keyboard-layout cycle us "bg phonetic"`  

<img align="right" src="https://github.com/slaviber/Stanislav_Beregov_tues/blob/master/2019-10-27-193435_1920x1080_scrot.png?raw=true">  
<hr>
<img align="right" src="https://github.com/slaviber/Stanislav_Beregov_tues/blob/master/2019-10-27-193447_1920x1080_scrot.png?raw=true">