### PR TITLE
Add option to specify multiple layouts as one parameter

### DIFF
--- a/i3-keyboard-layout
+++ b/i3-keyboard-layout
@@ -3,7 +3,7 @@
 set -e
 
 get_kbdlayout() {
-  layout=$(setxkbmap -query | grep -oP 'layout:\s*\K(\w+)')
+  layout=$(setxkbmap -query | grep -oP 'layout:\s*\K([\w,]+)')
   variant=$(setxkbmap -query | grep -oP 'variant:\s*\K(\w+)')
   echo "$layout" "$variant"
 }


### PR DESCRIPTION
This is useful if you want to use one language layout but have other layout shortcuts.
So I'm using `ru,us` to have russian keyboard layout but be able to use common shortcuts like `ctrl+a` to select text, etc..